### PR TITLE
Additional prepare method and lastrowid function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ stmt = DBInterface.prepare(conn, sql) # prepare a sql statement against the conn
 
 results = DBInterface.execute!(stmt) # execute a prepared statement; returns an iterator of rows (property-accessible & indexable)
 
+rowid = DBInterface.lastrowid(results) # get the last row id of an INSERT statement, as supported by the database
+
 # example of using a query resultset
 for row in results
     @show propertynames(row) # see possible column names of row results
@@ -46,4 +48,5 @@ DBInterface.close!
 DBInterface.Statement
 DBInterface.prepare
 DBInterface.execute!
+DBInterface.lastrowid
 ```

--- a/src/DBInterface.jl
+++ b/src/DBInterface.jl
@@ -110,7 +110,14 @@ function executemany!(stmt::Statement, args...; kw...)
     return
 end
 
-DBInterface.executemany!(conn::Connection, sql::AbstractString, args...; kw...) = DBInterface.executemany!(DBInterface.prepare(conn, sql), args...; kw...)
+executemany!(conn::Connection, sql::AbstractString, args...; kw...) = executemany!(prepare(conn, sql), args...; kw...)
+
+"""
+    DBInterface.lastrowid(x::Cursor) => Int
+
+If supported by the specific database cursor, returns the last inserted row id after executing an INSERT statement.
+"""
+lastrowid(::T) where {T} = throw(NotImplementedError("`DBInterface.lastrowid` not implemented for $T"))
 
 """
     DBInterface.close!(x::Cursor) => Nothing

--- a/src/DBInterface.jl
+++ b/src/DBInterface.jl
@@ -20,21 +20,44 @@ Immediately closes a database connection so further queries cannot be processed.
 """
 function close! end
 
-close!(conn::DBInterface.Connection) = throw(NotImplementedError("`DBInterface.close!` not implemented for `$(typeof(conn))`"))
+close!(conn::Connection) = throw(NotImplementedError("`DBInterface.close!` not implemented for `$(typeof(conn))`"))
 
 "Database packages should provide a `DBInterface.Statement` subtype which represents a valid, prepared SQL statement that can be executed repeatedly"
 abstract type Statement end
 
 """
     DBInterface.prepare(conn::DBInterface.Connection, sql::AbstractString) => DBInterface.Statement
+    DBInterface.prepare(f::Function, sql::AbstractString) => DBInterface.Statement
 
 Database packages should overload `DBInterface.prepare` for a specific `DBInterface.Connection` subtype, that validates and prepares
 a SQL statement given as an `AbstractString` `sql` argument, and returns a `DBInterface.Statement` subtype. It is expected
 that `DBInterface.Statement`s are only valid for the lifetime of the `DBInterface.Connection` object against which they are prepared.
+For convenience, users may call `DBInterface.prepare(f::Function, sql)` which first calls `f()` to retrieve a valid `DBInterface.Connection`
+before calling `DBInterface.prepare(conn, sql)`; this allows deferring connection retrieval and thus statement preparation until runtime,
+which is often convenient when building applications.
 """
 function prepare end
 
-prepare(conn::DBInterface.Connection, sql::AbstractString) = throw(NotImplementedError("`DBInterface.prepare` not implemented for `$(typeof(conn))`"))
+prepare(conn::Connection, sql::AbstractString) = throw(NotImplementedError("`DBInterface.prepare` not implemented for `$(typeof(conn))`"))
+prepare(f::Function, sql::AbstractString) = prepare(f(), sql)
+
+const PREPARED_STMTS = Dict{Symbol, Statement}()
+
+"""
+    DBInterface.@prepare f sql
+
+Takes a `DBInterface.Connection`-retrieval function `f` and SQL statement `sql` and will return a prepared statement, via usage of `DBInterface.prepare`.
+If the statement has already been prepared, it will be re-used (prepared statements are cached).
+"""
+macro prepare(getDB, sql)
+    key = gensym()
+    return quote
+        get!(DBInterface.PREPARED_STMTS, $(QuoteNode(key))) do
+            println("preparing stmt")
+            DBInterface.prepare($(esc(getDB)), $sql)
+        end
+    end
+end
 
 "Any object that iterates \"rows\", which are objects that are property-accessible and indexable. See `DBInterface.execute!` for more details on fetching query results."
 abstract type Cursor end
@@ -54,9 +77,9 @@ do not return results, an iterator is still expected to be returned that just it
 """
 function execute! end
 
-execute!(stmt::DBInterface.Statement, args...; kw...) = throw(NotImplementedError("`DBInterface.execute!` not implemented for `$(typeof(stmt))`"))
+execute!(stmt::Statement, args...; kw...) = throw(NotImplementedError("`DBInterface.execute!` not implemented for `$(typeof(stmt))`"))
 
-DBInterface.execute!(conn::Connection, sql::AbstractString, args...; kw...) = DBInterface.execute!(DBInterface.prepare(conn, sql), args...; kw...)
+execute!(conn::Connection, sql::AbstractString, args...; kw...) = execute!(prepare(conn, sql), args...; kw...)
 
 """
     DBInterface.executemany!(conn::DBInterface.Connect, sql::AbstractString, args...; kw...) => Nothing
@@ -64,14 +87,14 @@ DBInterface.execute!(conn::Connection, sql::AbstractString, args...; kw...) = DB
 
 Similar to 
 """
-function executemany!(stmt::DBInterface.Statement, args...; kw...)
+function executemany!(stmt::Statement, args...; kw...)
     if !isempty(args)
         arg = args[1]
         len = length(arg)
         all(x -> length(x) == len, args) || throw(ParameterError("positional parameters provided to `DBInterface.executemany!` do not all have the same number of parameters"))
         for i = 1:len
             xargs = map(x -> x[i], args)
-            DBInterface.execute!(stmt, xargs...)
+            execute!(stmt, xargs...)
         end
     elseif !isempty(kw)
         k = kw[1]
@@ -79,10 +102,10 @@ function executemany!(stmt::DBInterface.Statement, args...; kw...)
         all(x -> length(x) == len, kw) || throw(ParameterError("named parameters provided to `DBInterface.executemany!` do not all have the same number of parameters"))
         for i = 1:len
             xargs = collect(k=>v[i] for (k, v) in kw)
-            DBInterface.execute!(stmt; xargs...)
+            execute!(stmt; xargs...)
         end
     else
-        DBInterface.execute!(stmt)
+        execute!(stmt)
     end
     return
 end


### PR DESCRIPTION
Adds a method:
```julia
DBInterface.prepare(f::Function, sql) = ...
```
where calling `f()` should return a `DBInterface.Connection`. This is convenient in applications where the Connection is more dynamic and should be retrieved at runtime.

Also adds a convenience macro:
```julia
DBInterface.@prepare getDB sql
```
That expands to checking if `sql` has been prepared and cached yet and if not, calls the new `prepare` function with the `getDB` function.

2nd commit adds a new interface method `DBInterface.lastrowid(x::Cursor)` for databases that support this.