### PR TITLE
Introduce `executemultiple` for returning multiple resultsets from

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ DBInterface.execute(stmt, (col1=1, col2=3.14)) # execute the prepared INSERT sta
 
 DBInterface.executemany(stmt, (col1=[1,2,3,4,5], col2=[3.14, 1.23, 2.34 3.45, 4.56])) # execute the prepared statement multiple times for each set of named parameters; each named parameter must be an indexable collection
 
+results = DBInterface.executemultiple(conn, sql) # where sql is a query that returns multiple resultsets
+
+# first iterate through resultsets
+for result in results
+    # for each resultset, we can iterate through resultset rows
+    for row in result
+        @show propertynames(row)
+        row.col1
+        row[1]
+    end
+end
+
 DBInterface.close!(stmt) # close the prepared statement
 ```
 
@@ -50,5 +62,6 @@ DBInterface.close!
 DBInterface.Statement
 DBInterface.prepare
 DBInterface.execute
+DBInterface.executemultiple
 DBInterface.lastrowid
 ```


### PR DESCRIPTION
single query

Lots of databases (and even the ODBC spec) support returning multiple
resultsets from a single query execution call (usually the individual
sql queries must be separated by semi-colons, but stored procedures can
also return multiple resultsets). This formalizes the idea by
introducing `DBInterface.executemultiple`, which looks and acts exactly
like `DBInterface.execute` (takes `conn` arg, query string, params,
etc.), except instead of returning a single `Cursor`, it returns an
iterator of `Cursor`s. I like that this doesn't affect/change `execute`
at all, and is strictly additive in functionality for the interface
overall.