### PR TITLE
execute(): support passing parameters as keyword arguments

### DIFF
--- a/src/DBInterface.jl
+++ b/src/DBInterface.jl
@@ -1,5 +1,14 @@
 module DBInterface
 
+"""
+Declare the string as written in SQL.
+
+The macro doesn't do any processing of the string.
+"""
+macro sql_str(cmd)
+    cmd
+end
+
 "Database packages should subtype `DBInterface.Connection` which represents a connection to a database"
 abstract type Connection end
 


### PR DESCRIPTION
This PR complements JuliaDatabases/SQLite.jl#223 by adding keyarg support to *DBInterface* (for *execute()*, *executemultiple()* and *executemany()*).

I've also added two other minor things:
   * `@sql_str` macro, so that SQL queries could be written as `@sql"...."`. This should allow embedded SQL highlighting in Julia scripts by IDE plugins as it is done for e.g. `@r_str` strings of *RCall.jl*.
   * `execute(f, db, sql)`, which (as `open(f, file)`) allows applying `f` to the returned cursor and then closing the query (the query is also closed if `f` throws).
     This pattern allows tighter control of the prepared statement lifetime, which does not rely on GC to finalize and close the statement object. It also allows DB-specific implementations that don't create prepared statements at all.