### PR TITLE
Export `@sql_str` macro

### DIFF
--- a/src/DBInterface.jl
+++ b/src/DBInterface.jl
@@ -1,5 +1,7 @@
 module DBInterface
 
+export @sql_str;
+
 """
 Declare the string as written in SQL.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
 using DBInterface, Test
 
 @test_throws MethodError DBInterface.connect(Int64)
+
+# test @sql_str macro (does nothing)
+@test sql"SELECT * FROM MyTable" == "SELECT * FROM MyTable"


### PR DESCRIPTION
Fixes the export of `@sql_str` missing from #30.
Meanwhile the next versions of *VSCode*/*Atom* *Julia* plugins should have support for SQL highlighting inside `sql"..."` strings.